### PR TITLE
v0.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 ﻿cmake_minimum_required(VERSION 3.20.0)
 
+# This configuration is for linux only
+
 # Project info
 project(
         MgxParser
-        VERSION 0.4.3
+        VERSION 0.5.0
         LANGUAGES CXX
         HOMEPAGE_URL "https://github.com/lichifeng/MgxParser"
         DESCRIPTION "MgxParser is a C++ lib used to parse Age of Empires II game records."
@@ -13,37 +15,9 @@ project(
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_POSITION_INDEPENDENT_CODE true)
-add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
-add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 set(USE_BM_SEARCH 1)
 
-if (APPLE)
-    # Mac hack, libiconv and libpng was install with brew
-    include_directories(/opt/homebrew/opt/libpng/include)
-    link_directories(/opt/homebrew/opt/libpng/lib)
-    set(MGXPARSER_LINK_TARGETS pthread png z iconv)
-    set(USE_BM_SEARCH 0)
-elseif (WIN32)
-    # windows with vcpkg
-    include_directories(
-            "D:\\vcpkg\\vcpkg\\packages\\zlib_x64-windows-static\\include"
-            "D:\\vcpkg\\vcpkg\\packages\\libiconv_x64-windows-static\\include"
-            "D:\\vcpkg\\vcpkg\\packages\\libpng_x64-windows-static\\include"
-            "D:\\vcpkg\\vcpkg\\packages\\pthreads_x64-windows-static\\lib"
-    )
-    link_directories(
-            "D:\\vcpkg\\vcpkg\\packages\\zlib_x64-windows-static\\lib"
-            "D:\\vcpkg\\vcpkg\\packages\\libiconv_x64-windows-static\\lib"
-            "D:\\vcpkg\\vcpkg\\packages\\libpng_x64-windows-static\\lib"
-            "D:\\vcpkg\\vcpkg\\packages\\pthreads_x64-windows-static\\lib"
-    )
-    add_compile_definitions(_HAS_STD_BYTE=0)
-    set(MGXPARSER_LINK_TARGETS pthreadvc3 libpng16 zlib iconv)
-else ()
-    set(MGXPARSER_LINK_TARGETS pthread png z stdc++fs)
-endif ()
-
-# List source files to be compiled
+# Prepare source files to be compiled
 aux_source_directory(./src SRC_ROOT)
 aux_source_directory(src/tools TOOLS)
 aux_source_directory(src/analyzers/default DEFAULT_ANALYZER)
@@ -51,19 +25,26 @@ aux_source_directory(src/analyzers/default/body_processors DEFAULT_ANALYZER_BODY
 aux_source_directory(./libs/md5 MD5)
 set(MGXPARSER_SRCS ${DEFAULT_ANALYZER} ${DEFAULT_ANALYZER_BODY} ${MD5} ${SRC_ROOT} ${TOOLS})
 
+# Prepare dependency libraries
+# WARNING: png depends on libz, so put it before z
+set(MGXPARSER_DEPENDENCIES png z)
+
+# Create static and shared libraries
 add_library("${PROJECT_NAME}_OBJECT" OBJECT ${MGXPARSER_SRCS})
 add_library("${PROJECT_NAME}_SHARED" SHARED $<TARGET_OBJECTS:${PROJECT_NAME}_OBJECT>)
 add_library("${PROJECT_NAME}_STATIC" STATIC $<TARGET_OBJECTS:${PROJECT_NAME}_OBJECT>)
-add_executable("${PROJECT_NAME}_EXE" demo.cc)
+target_link_libraries("${PROJECT_NAME}_SHARED" ${MGXPARSER_DEPENDENCIES})
+target_link_libraries("${PROJECT_NAME}_STATIC" ${MGXPARSER_DEPENDENCIES})
 
-# Import dependencies
-# WARNING: png depends on libz, so put it before z
-target_link_libraries("${PROJECT_NAME}_SHARED" ${MGXPARSER_LINK_TARGETS})
-target_link_libraries("${PROJECT_NAME}_STATIC" ${MGXPARSER_LINK_TARGETS})
-target_link_libraries("${PROJECT_NAME}_EXE" "${PROJECT_NAME}_STATIC" ${MGXPARSER_LINK_TARGETS})
+# Create static and shared executables
+add_executable("${PROJECT_NAME}_S_EXE" demo.cc)
+target_link_libraries("${PROJECT_NAME}_S_EXE" ${PROJECT_NAME}_STATIC)
+target_link_options("${PROJECT_NAME}_S_EXE" PRIVATE "-static")
+add_executable("${PROJECT_NAME}_D_EXE" demo.cc)
+target_link_libraries("${PROJECT_NAME}_D_EXE" ${PROJECT_NAME}_SHARED)
 
 set(
-        MGXPARSER_INCLUDE_
+        MGXPARSER_INCLUDE
         PUBLIC
         "${CMAKE_CURRENT_SOURCE_DIR}/libs/"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/"
@@ -72,12 +53,9 @@ set(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/datamodels/"
         "${PROJECT_BINARY_DIR}" 
 )
-set(MGXPARSER_INCLUDE ${MGXPARSER_INCLUDE_})
-set(MGXPARSER_INCLUDE ${MGXPARSER_INCLUDE_} PARENT_SCOPE)
 target_include_directories("${PROJECT_NAME}_OBJECT" PRIVATE ${MGXPARSER_INCLUDE})
-target_include_directories("${PROJECT_NAME}_SHARED" PRIVATE ${MGXPARSER_INCLUDE})
-target_include_directories("${PROJECT_NAME}_STATIC" PRIVATE ${MGXPARSER_INCLUDE})
-target_include_directories("${PROJECT_NAME}_EXE" PRIVATE ${MGXPARSER_INCLUDE})
+target_include_directories("${PROJECT_NAME}_D_EXE" PRIVATE ${MGXPARSER_INCLUDE})
+target_include_directories("${PROJECT_NAME}_S_EXE" PRIVATE ${MGXPARSER_INCLUDE})
 
 # Import some environment variables and generate docs, etc.
 string(TIMESTAMP COMPILEDATE "%Y%m%d")
@@ -85,6 +63,7 @@ target_compile_definitions("${PROJECT_NAME}_OBJECT" PRIVATE "DEBUG=$<CONFIG:Debu
 configure_file(compile_config.h.in compile_config.h)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/README.md ${CMAKE_CURRENT_SOURCE_DIR})
 add_definitions(-DCMAKE_EXPORT_COMPILE_COMMANDS=ON)
+
 # Update doxygen configuration file and generate output HTML
 find_package(Doxygen)
 option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation (requires Doxygen)" ${DOXYGEN_FOUND})
@@ -111,7 +90,7 @@ endif ()
 
 # Testing configuration
 # https://coderefinery.github.io/cmake-workshop/testing/
-set(BUILD_TESTING 1)
+set(BUILD_TESTING 0)
 if (BUILD_TESTING)
     set(CMP0135 1)
     set(DOWNLOAD_EXTRACT_TIMESTAMP 1)
@@ -129,24 +108,18 @@ if (BUILD_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cc
     )
     target_include_directories("${PROJECT_NAME}_TEST" PRIVATE ${MGXPARSER_INCLUDE})
-    target_link_libraries("${PROJECT_NAME}_TEST" "${PROJECT_NAME}_STATIC" ${MGXPARSER_LINK_TARGETS})
+    target_link_libraries("${PROJECT_NAME}_TEST" ${PROJECT_NAME}_STATIC ${MGXPARSER_LINK_TARGETS})
     target_link_libraries("${PROJECT_NAME}_TEST" GTest::gtest_main)
     add_executable(
             "CURSOR_TEST"
             ${CMAKE_CURRENT_SOURCE_DIR}/test/cursor_test.cc
             src/tools/cursor.cc
     )
-    target_link_libraries("CURSOR_TEST" "${PROJECT_NAME}_STATIC" ${MGXPARSER_LINK_TARGETS})
+    target_link_libraries("CURSOR_TEST" ${PROJECT_NAME}_STATIC ${MGXPARSER_LINK_TARGETS})
     target_link_libraries("CURSOR_TEST" GTest::gtest_main)
     include(GoogleTest)
     gtest_discover_tests("${PROJECT_NAME}_TEST")
     gtest_discover_tests("CURSOR_TEST")
 endif ()
 
-# Static linking
-if (NOT APPLE)
-    target_link_options("${PROJECT_NAME}_EXE" PRIVATE "-static")
-    #warning: Using 'getaddrinfo' in statically linked applications requires at runtime 
-    #the shared libraries from the glibc version used for linking
-    #target_link_options("${PROJECT_NAME}_TEST" PRIVATE "-static")
-endif ()
+message("Build type: ${CMAKE_BUILD_TYPE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,12 @@
 # Project info
 project(
         MgxParser
-        VERSION 0.5.0
+        VERSION 0.4.2
         LANGUAGES CXX
         HOMEPAGE_URL "https://github.com/lichifeng/MgxParser"
         DESCRIPTION "MgxParser is a C++ lib used to parse Age of Empires II game records."
 )
+message("Build type: ${CMAKE_BUILD_TYPE}")
 
 # Some basic configurations
 set(CMAKE_CXX_STANDARD 17)
@@ -57,6 +58,29 @@ target_include_directories("${PROJECT_NAME}_OBJECT" PRIVATE ${MGXPARSER_INCLUDE}
 target_include_directories("${PROJECT_NAME}_D_EXE" PRIVATE ${MGXPARSER_INCLUDE})
 target_include_directories("${PROJECT_NAME}_S_EXE" PRIVATE ${MGXPARSER_INCLUDE})
 
+# Compile Node.js Addon
+add_definitions(-DNAPI_VERSION=3)
+# 检查napi.h是否存在于CMAKE_JS_INC目录中
+find_path(NAPI_H_FOUND "node_api.h" PATHS ${CMAKE_JS_INC})
+
+# 如果napi.h和CMAKE_JS_LIB都存在，创建mgxnodeS库
+if(NAPI_H_FOUND)
+        # Include Node-API wrappers
+        execute_process(COMMAND node -p "require('node-addon-api').include"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE NODE_ADDON_API_DIR
+        )
+        string(REGEX REPLACE "[\r\n\"]" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+
+        set(NODE_ADDON_NAME "mgxnode")
+        add_library(${NODE_ADDON_NAME} SHARED $<TARGET_OBJECTS:${PROJECT_NAME}_OBJECT> mgxnode.cc)
+        set_target_properties(${NODE_ADDON_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+        target_link_libraries(${NODE_ADDON_NAME} ${CMAKE_JS_LIB} ${MGXPARSER_DEPENDENCIES})
+        target_include_directories(${NODE_ADDON_NAME} PRIVATE ${MGXPARSER_INCLUDE} ${CMAKE_JS_INC} ${NODE_ADDON_API_DIR})
+else()
+        message("cmake-js not found, mgxnode library will not be created.")
+endif()
+
 # Import some environment variables and generate docs, etc.
 string(TIMESTAMP COMPILEDATE "%Y%m%d")
 target_compile_definitions("${PROJECT_NAME}_OBJECT" PRIVATE "DEBUG=$<CONFIG:Debug>")
@@ -67,7 +91,7 @@ add_definitions(-DCMAKE_EXPORT_COMPILE_COMMANDS=ON)
 # Update doxygen configuration file and generate output HTML
 find_package(Doxygen)
 option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation (requires Doxygen)" ${DOXYGEN_FOUND})
-if (BUILD_DOCUMENTATION AND NOT NODE_ADDON AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
+if (BUILD_DOCUMENTATION AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
     if (NOT DOXYGEN_FOUND)
         message(FATAL_ERROR "Doxygen is needed to build the documentation.")
     endif ()
@@ -90,7 +114,7 @@ endif ()
 
 # Testing configuration
 # https://coderefinery.github.io/cmake-workshop/testing/
-set(BUILD_TESTING 0)
+set(BUILD_TESTING 1)
 if (BUILD_TESTING)
     set(CMP0135 1)
     set(DOWNLOAD_EXTRACT_TIMESTAMP 1)
@@ -108,18 +132,16 @@ if (BUILD_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cc
     )
     target_include_directories("${PROJECT_NAME}_TEST" PRIVATE ${MGXPARSER_INCLUDE})
-    target_link_libraries("${PROJECT_NAME}_TEST" ${PROJECT_NAME}_STATIC ${MGXPARSER_LINK_TARGETS})
+    target_link_libraries("${PROJECT_NAME}_TEST" ${PROJECT_NAME}_STATIC)
     target_link_libraries("${PROJECT_NAME}_TEST" GTest::gtest_main)
     add_executable(
             "CURSOR_TEST"
             ${CMAKE_CURRENT_SOURCE_DIR}/test/cursor_test.cc
             src/tools/cursor.cc
     )
-    target_link_libraries("CURSOR_TEST" ${PROJECT_NAME}_STATIC ${MGXPARSER_LINK_TARGETS})
+    target_link_libraries("CURSOR_TEST" ${PROJECT_NAME}_STATIC)
     target_link_libraries("CURSOR_TEST" GTest::gtest_main)
     include(GoogleTest)
     gtest_discover_tests("${PROJECT_NAME}_TEST")
     gtest_discover_tests("CURSOR_TEST")
 endif ()
-
-message("Build type: ${CMAKE_BUILD_TYPE}")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # **MgxParser**
-*This version(0.4.3) was compiled on 20230301*
+*This version(0.5.0) was compiled on 20240205*
 
 ## Introduction
 MgxParser is a C++ lib used to parse Age of Empires II game records.
@@ -113,6 +113,7 @@ Node.js addon.
 Then `MgxParser::parse()` should be available.
 
 ## Version log
+- **0.5.0**: Organized CMake compile files, removed unnecessary historical code.
 - **0.4.0**: Prepare to go online. Add english language pack. Fixed more bugs.
 - **0.3.x**: Bug fix and some changes to meet requirements of mgxhub.
 - **0.2.0**: Reoragnized source files, tested with 130000+ records in
@@ -121,14 +122,14 @@ Then `MgxParser::parse()` should be available.
   record. All operations are done in memory without file storage.
 
 ## Resources
-Find records for test: https://www.ageofempires.com/stats/ageiide
-https://github.com/topics/age-of-empires
-DE Replays Manager: https://github.com/gregstein/DE-Replays-Manager
-Awesome Age of Empires II resources: https://github.com/Arkanosis/awesome-aoe2
-https://aok.heavengames.com/blacksmith/lister.php?category=utilities
+Find records for test: https://www.ageofempires.com/stats/ageiide   
+https://github.com/topics/age-of-empires   
+DE Replays Manager: https://github.com/gregstein/DE-Replays-Manager   
+Awesome Age of Empires II resources: https://github.com/Arkanosis/awesome-aoe2   
+https://aok.heavengames.com/blacksmith/lister.php?category=utilities   
 https://aok.heavengames.com/blacksmith/lister.php?category=records   
-AoE II Development Collective https://siegeengineers.org/
-https://www.twaoe2wiki.com/
+AoE II Development Collective https://siegeengineers.org/   
+https://www.twaoe2wiki.com/   
 
 ## Caution
 This project is still under development. **No warrenty for anything!**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # **MgxParser**
-*This version(0.5.0) was compiled on 20240205*
+*This version(0.4.2) was compiled on 20240208*
 
 ## Introduction
 MgxParser is a C++ lib used to parse Age of Empires II game records.
@@ -8,10 +8,9 @@ It is firstly developed at 2020 to support running of aocrec.com as a
 replacement of a prior php parser( which was a modified version of recanalyst).
 
 ## Basic usage
-MgxParser exports two forms of `parse()` function:
+MgxParser `parse(Settings)` function:
 One takes a record file path as input and returns a JSON string contains
 important information about this record.  
-The other accepts a byte(uint8_t) array and parses the data.
 
 If input is a zip archive, MgxParser will try to Extract2Files first file in the
 archive and parse it as a record. This function is intended to tackle compressed
@@ -21,15 +20,31 @@ No error was expected even if something unexpected happend in parsing process.
 Users should check parsing result by the value of key `status` and `message` in
 JSON response.
 
-Mini maps can be generated two forms, too.   
-With `-m`, a typical map was generated, and   
-with `-M`, a prettier HD map was generated.
+**Read `src/include/MgxParse.h` for more details.**
 
-With `-e` to extract header and body data to .dat files for development usage.
+A demo of MgxParser will be compiled using demo.cc. It can be used to parse a
+record file and print the result to stdout.
+```sh
+mgxparser --help
+```
+Output:
+```sh
+Usage: ./mgxparser [options] [file]
+Options:
+  -m    Generate a normal map
+  -M    Generate a HD map
+  -u    Extract the original file in .zip archive
+  -j    Indentation of the json string. i.e. -j2
+  --help Display this help message
+Example: ./mgxparser -m -j2 demo.mgx
+```
+
+For node addon usage, see `src/node/README.md`,    
+See **Compile node addon with cmake-js** for details.
 
 ## Performance
-I did't do elegent profiling for it, simply measured its performance by `\time -v
-MgxParser recordfile.mgx`
+I did't do elegent profiling for it, simply measured its performance    
+by `\time -v MgxParser recordfile.mgx`   
 
 Pure json output without map generation is very fast. Normally cost
 <50ms and <10m peak memory( in my synology DS1621+ NAS docker container).
@@ -88,6 +103,10 @@ can be installed by:
 ```sh
 sudo snap install cmake --classic
 ```
+or
+```sh
+sudo apt-get install cmake
+```
 
 A C++17 compiler is also needed. `G++-9`, `Clang++-10` or newer compilers are
 recommended. Other compilers may work, but I never tested, too.
@@ -101,19 +120,22 @@ cmake . -DCMAKE_CXX_COMPILER=/usr/bin/clang++-10 -DCMAKE_BUILD_TYPE=Release --fr
 make
 ```
 
-## Compile with cmake-js
-- Use `add_subdirectories()` funtion of CMake to integrate MgxParser into a
-Node.js addon. 
-- `set(NODE_ADDON 1)` in root `CMakeLists.txt`, MgxParser should adjust the proper
-  CMake settings automatically.
-- Put `$<TARGET_OBJECTS:MgxParser>` as an `<item>` of `add_library()` directive
-  of root `CMakeLists.txt`.
-- Include `src/include/MgxParse.h`.
-
-Then `MgxParser::parse()` should be available.
+## Compile node addon with cmake-js
+To compile it to a node addon, `cmake-js` and `node-addon-api` is required.   
+Use `npm` to install `cmake-js` and `node-addon-api`:
+```sh
+npm install
+```
+Then, compile it with `cmake-js`:
+```sh
+npx cmake-js compile -p 6 # or other threads settings
+```
+The compiled node addon will be in `build/Release` directory.   
+A demo of node addon is in `test/node_addon_test.js` directory.
 
 ## Version log
-- **0.5.0**: Organized CMake compile files, removed unnecessary historical code.
+- **0.4.2**: Reorganized source code. Refactored `parse()` function. Add node addon support.   
+- **0.4.1**: A version used on aocrec.com before Feb. 2024.
 - **0.4.0**: Prepare to go online. Add english language pack. Fixed more bugs.
 - **0.3.x**: Bug fix and some changes to meet requirements of mgxhub.
 - **0.2.0**: Reoragnized source files, tested with 130000+ records in
@@ -122,14 +144,14 @@ Then `MgxParser::parse()` should be available.
   record. All operations are done in memory without file storage.
 
 ## Resources
-Find records for test: https://www.ageofempires.com/stats/ageiide   
-https://github.com/topics/age-of-empires   
-DE Replays Manager: https://github.com/gregstein/DE-Replays-Manager   
-Awesome Age of Empires II resources: https://github.com/Arkanosis/awesome-aoe2   
-https://aok.heavengames.com/blacksmith/lister.php?category=utilities   
+Find records for test: https://www.ageofempires.com/stats/ageiide
+https://github.com/topics/age-of-empires
+DE Replays Manager: https://github.com/gregstein/DE-Replays-Manager
+Awesome Age of Empires II resources: https://github.com/Arkanosis/awesome-aoe2
+https://aok.heavengames.com/blacksmith/lister.php?category=utilities
 https://aok.heavengames.com/blacksmith/lister.php?category=records   
-AoE II Development Collective https://siegeengineers.org/   
-https://www.twaoe2wiki.com/   
+AoE II Development Collective https://siegeengineers.org/
+https://www.twaoe2wiki.com/
 
 ## Caution
 This project is still under development. **No warrenty for anything!**

--- a/demo.cc
+++ b/demo.cc
@@ -2,52 +2,68 @@
  * \file       demo.cpp
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <cstring>
 #include <iostream>
 #include <string>
-
+#include <cstdlib>
+#include <unistd.h>
 #include "include/MgxParser.h"
 
-int main(int argc, char *argv[]) {
-    if (argc <= 1) {
-        std::cout << "No Record Specified!" << std::endl;
-        return 1;
-    }
 
-    int map_type = NO_MAP;
-    bool extract = false;
+int main(int argc, char *argv[]) {
+    MgxParser::MapType map_type = MgxParser::NO_MAP;
     std::string file_path;
     std::string unzip_filename;
-    for (size_t i = 0; i < argc; i++) {
-        const char *argm = "-m";
-        const char *argM = "-M";
-        const char *arge = "-e";
-        const char *argu = "-u";
+    int json_indent = -1;
 
-        if (0 == strcmp(argm, argv[i]))
-            map_type = NORMAL_MAP;
-        else if (0 == strcmp(argM, argv[i]))
-            map_type = HD_MAP;
-        else if (0 == strcmp(arge, argv[i]))
-            extract = true;
-        else if (0 == strcmp(argu, argv[i]))
-            unzip_filename = "original"; // use original filename in .zip archive
-        else
-            file_path.assign(argv[i]);
+    int opt;
+    while ((opt = getopt(argc, argv, "mMun:")) != -1) {
+        switch (opt) {
+            case 'm':
+                map_type = MgxParser::NORMAL_MAP;
+                break;
+            case 'M':
+                map_type = MgxParser::HD_MAP;
+                break;
+            case 'u':
+                unzip_filename = "original"; // use original filename in .zip archive
+                break;
+            case 'n':
+                json_indent = std::atoi(optarg);
+                if (json_indent <= 0) {
+                    std::cerr << "Error: json_indent must be a number greater than 0.\n";
+                    return 1;
+                }
+                break;
+            default:
+                std::cout << "Usage: ./mgxparser [options] [file]\n"
+                          << "Options:\n"
+                          << "  -m    Generate a normal map\n"
+                          << "  -M    Generate a HD map\n"
+                          << "  -u    Extract the original file in .zip archive\n"
+                          << "  -n    Indentation of the json string. i.e. -2\n"
+                          << "  --help Display this help message\n"
+                          << "Example: ./mgxparser -m -n4 demo.mgx\n";
+                return 1;
+        }
+    }
+
+    if (optind < argc) {
+        file_path.assign(argv[optind]);
+    } else {
+        std::cout << "No Record Specified!" << std::endl;
+        return 1;
     }
 
     MgxParser::Settings _ = {.input_path = file_path,
                              .map_type = map_type,
                              .map_width = 900,
                              .map_height = 450,
-                             .map_name = "map.png",
-                             .extract_stream = extract,
-                             .header_path = extract ? "header.dat" : "",
-                             .body_path = extract ? "body.dat" : "",
-                             .unzip = unzip_filename};
+                             .json_indent = json_indent};
+
     std::cout << MgxParser::parse(_) << std::endl;
 
     return 0;

--- a/mgxnode.cc
+++ b/mgxnode.cc
@@ -1,0 +1,160 @@
+#include <napi.h>
+#include <cstdio>
+
+#include "MgxParser.h"
+
+static Napi::Object Method(const Napi::CallbackInfo &info)
+{
+    // Napi::Env is the opaque data structure containing the environment in which the request is being run.
+    // We will need this env when we want to create any new objects inside of the node.js environment
+    Napi::Env env = info.Env();
+    Napi::Object config;
+    MgxParser::Settings _;
+
+    if (info.Length() < 1)
+    {
+        Napi::TypeError::New(env, "No record or config object specified.").ThrowAsJavaScriptException();
+        return Napi::Object::New(env);
+    }
+    else
+    {
+        if (info[0].IsObject())
+        {
+            config = info[0].As<Napi::Object>();
+        }
+        else
+        {
+            config = Napi::Object::New(env);
+        }
+    }
+
+    // extract parsing settings
+    if (config.Has("input"))
+    {
+        if (config.Get("input").IsBuffer())
+        {
+            auto rawbuf = config.Get("input").As<Napi::Buffer<uint8_t>>();
+            _.input_stream = rawbuf.Data();
+            _.input_size = rawbuf.Length();
+        }
+        else if (config.Get("input").IsString())
+        {
+            _.input_path = config.Get("input").ToString().Utf8Value();
+        }
+    }
+
+    if (config.Has("map") && config.Get("map").IsString())
+    {
+        std::string map_type = config.Get("map").ToString().Utf8Value();
+
+        if ("normal" == map_type)
+        {
+            _.map_type = MgxParser::NORMAL_MAP;
+        }
+        else if ("hd" == map_type)
+        {
+            _.map_type = MgxParser::HD_MAP;
+        }
+        else
+        {
+            _.map_type = MgxParser::NO_MAP;
+        }
+
+        if (config.Has("mapWidth") && config.Get("mapWidth").IsNumber())
+        {
+            _.map_width = config.Get("mapWidth").ToNumber();
+        }
+        if (config.Has("mapHeight") && config.Get("mapHeight").IsNumber())
+        {
+            _.map_height = config.Get("mapHeight").ToNumber();
+        }
+    }
+    if (config.Has("mapName") && config.Get("mapName").IsString())
+    {
+        _.map_path = config.Get("mapName").ToString().Utf8Value();
+    }
+    if (config.Has("header") && config.Get("header").IsString())
+    {
+        _.header_path = config.Get("header").ToString().Utf8Value();
+    }
+    if (config.Has("body") && config.Get("body").IsString())
+    {
+        _.body_path = config.Get("body").ToString().Utf8Value();
+    }
+    if (config.Has("fullParse") && config.Get("fullParse").IsBoolean())
+    {
+        _.full_parse = config.Get("fullParse").ToBoolean().Value();
+    }
+    if (config.Has("md5") && config.Get("md5").IsBoolean())
+    {
+        _.calc_md5 = config.Get("md5").ToBoolean().Value();
+    }
+    if (config.Has("jsonIndent") && config.Get("jsonIndent").IsNumber())
+    {
+        _.json_indent = config.Get("jsonIndent").ToNumber();
+    }
+
+    // check if map buffer requested
+    char *out_buffer = nullptr;
+    std::size_t map_size = 0;
+    if (_.map_type > 0 && _.map_path.empty())
+    {
+        _.map_dest = open_memstream(&out_buffer, &map_size);
+    }
+
+    // check if need unzipping
+    char *unzip_dest = nullptr;
+    std::size_t unzip_size = 0;
+    if (config.Has("unzip") && config.Get("unzip").IsString())
+    {
+        std::string unzip_type = config.Get("unzip").ToString().Utf8Value();
+        if ("buffer" == unzip_type)
+        {
+            _.unzip_buffer = &unzip_dest;
+            _.unzip_size_ptr = &unzip_size;
+        }
+        else
+        {
+            _.unzip = unzip_type;
+        }
+    }
+
+    // do parsing
+    auto recinfo = MgxParser::parse(_);
+    if (_.map_dest)
+        fclose(_.map_dest);
+
+    // Return a new javascript string that we copy-construct inside of the node.js environment
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set("result", recinfo);
+
+    // populate map buffer if exists
+    if (map_size > 0 && out_buffer)
+    {
+        auto map_buffer = Napi::Buffer<char>::New(env, out_buffer, map_size, [](napi_env e, char *b)
+                                                  {
+            if (b)
+                free(b); });
+        obj.Set("mapbuffer", map_buffer);
+    }
+
+    // populate unzip buffer if required
+    if (unzip_dest && unzip_size)
+    {
+        auto unzip_buffer = Napi::Buffer<char>::New(env, unzip_dest, unzip_size, [](napi_env e, char *b)
+                                                    {
+                if (b)
+                    free(b); });
+        obj.Set("unzipbuffer", unzip_buffer);
+    }
+
+    return obj;
+}
+
+static Napi::Object Init(Napi::Env env, Napi::Object exports)
+{
+    exports.Set("parse", Napi::Function::New(env, Method));
+    return exports;
+}
+
+NODE_API_MODULE(mgxnode, Init)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,699 @@
+{
+  "name": "MgxParser",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "cmake-js": "^7.3.0",
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cmake-js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.3.0.tgz",
+      "integrity": "sha512-dXs2zq9WxrV87bpJ+WbnGKv8WUBXDw8blNiwNHoRe/it+ptscxhQHKB1SJXa1w+kocLMeP28Tk4/eTCezg4o+w==",
+      "dependencies": {
+        "axios": "^1.6.5",
+        "debug": "^4",
+        "fs-extra": "^11.2.0",
+        "lodash.isplainobject": "^4.0.6",
+        "memory-stream": "^1.0.0",
+        "node-api-headers": "^1.1.0",
+        "npmlog": "^6.0.2",
+        "rc": "^1.2.7",
+        "semver": "^7.5.4",
+        "tar": "^6.2.0",
+        "url-join": "^4.0.1",
+        "which": "^2.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "cmake-js": "bin/cmake-js"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/memory-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-1.0.0.tgz",
+      "integrity": "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==",
+      "dependencies": {
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
+    },
+    "node_modules/node-api-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.1.0.tgz",
+      "integrity": "sha512-ucQW+SbYCUPfprvmzBsnjT034IGRB2XK8rRc78BgjNKhTdFKgAwAmgW704bKIBmcYW48it0Gkjpkd39Azrwquw=="
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "cmake-js": "^7.3.0",
+    "node-addon-api": "^7.1.0"
+  },
+  "binary": {
+    "napi_versions": [
+      7
+    ]
+  }
+}

--- a/src/MgxParser.cc
+++ b/src/MgxParser.cc
@@ -2,7 +2,7 @@
  * \file       MgxParser.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <string>
@@ -10,71 +10,71 @@
 #include "include/MgxParser.h"
 #include "analyzers/default/analyzer.h"
 
-std::string _parse(DefaultAnalyzer &&a, int map_type, FILE *map_dest, const std::string &map_name, int map_width,
-                   int map_height, bool extract = false, const std::string &header_path = "",
-                   const std::string &body_path = "", bool full_parse = true, bool md5 = true,
-                   const std::string &unzip = "", char **unzip_buffer = nullptr, std::size_t *unzip_size_ptr = nullptr) {
-    if (full_parse) {
-        try {
-            a.calc_md5_ = md5;
-            if (!unzip.empty())
-                a.unzip_ = unzip;
-            a.unzip_buffer_ = unzip_buffer;
-            a.unzip_size_ptr_ = unzip_size_ptr;
+static std::string _parse(DefaultAnalyzer &&a, MgxParser::Settings &s)
+{
+    if (s.full_parse)
+    {
+        try
+        {
+            a.calc_md5_ = s.calc_md5;
+            if (!s.unzip.empty())
+                a.unzip_ = s.unzip;
+            a.unzip_buffer_ = s.unzip_buffer;
+            a.unzip_size_ptr_ = s.unzip_size_ptr;
             a.Run();
-        } catch (std::string &s) {
-            a.logger_->Fatal("Df#{}@{}/{}: {}", a.status_.debug_flag_, a.Position(), a.TotalSize(), s);
-        } catch (const std::exception &e) {
+        }
+        catch (const std::string &msg)
+        {
+            a.logger_->Fatal("Df#{}@{}/{}: {}", a.status_.debug_flag_, a.Position(), a.TotalSize(), msg);
+        }
+        catch (const std::exception &e)
+        {
             a.logger_->Fatal("Df#{}@{}/{}: {}", a.status_.debug_flag_, a.Position(), a.TotalSize(), e.what());
-        } catch (...) {
+        }
+        catch (...)
+        {
             a.logger_->Fatal("Df#{}@{}/{}: Unknown Exception!", a.status_.debug_flag_, a.Position(), a.TotalSize());
         }
         a.parse_time_ = a.logger_->Elapsed();
     }
 
-    if (map_type != NO_MAP) {
-        if (map_width < 0)
-            map_width = 300;
-        if (map_height < 0)
-            map_height = 150;
-        try {
-            if (map_dest) {
-                a.DrawMap(map_dest, map_width, map_height, map_type == HD_MAP);
+    if (s.map_type != MgxParser::NO_MAP)
+    {
+        try
+        {
+            if (s.map_dest)
+            {
+                a.DrawMap(s.map_dest, s.map_width, s.map_height, s.map_type == MgxParser::HD_MAP);
             }
-            if (!map_name.empty()) {
-                a.DrawMap(map_name, map_width, map_height, map_type == HD_MAP);
+            else
+            {
+                a.DrawMap(s.map_path.empty() ? "minimap.png" : s.map_path, s.map_width, s.map_height, s.map_type == MgxParser::HD_MAP);
             }
-        } catch (...) {
+        }
+        catch (...)
+        {
             a.logger_->Warn("Failed to generate a map file.");
         }
     }
 
-    if (extract || !header_path.empty() || !body_path.empty()) {
-        a.Extract2Files(header_path, body_path);
+    if (!s.header_path.empty() || !s.body_path.empty())
+    {
+        a.Extract2Files(s.header_path, s.body_path);
     }
 
     a.message_ = std::move(a.logger_->DumpStr());
 
-    return a.JsonOutput();
+    return a.JsonOutput(s.json_indent);
 }
 
-std::string MgxParser::parse(Settings &settings) {
-    if (settings.input_stream && settings.input_size > 0) {
-        return _parse(DefaultAnalyzer(settings.input_stream, settings.input_size, settings.input_path),
-                      settings.map_type, settings.map_dest, settings.map_name, settings.map_width, settings.map_height,
-                      settings.extract_stream, settings.header_path, settings.body_path, settings.full_parse,
-                      settings.md5, settings.unzip, settings.unzip_buffer, settings.unzip_size_ptr);
-    } else {
-        return _parse(DefaultAnalyzer(settings.input_path), settings.map_type, settings.map_dest, settings.map_name,
-                      settings.map_width, settings.map_height, settings.extract_stream, settings.header_path,
-                      settings.body_path, settings.full_parse, settings.md5, settings.unzip, settings.unzip_buffer,
-                      settings.unzip_size_ptr);
+std::string MgxParser::parse(MgxParser::Settings &s)
+{
+    if (s.input_stream && s.input_size > 0)
+    {
+        return _parse(DefaultAnalyzer(s.input_stream, s.input_size, s.input_path), s);
     }
-}
-
-extern "C" {
-const char *MgxParser::pyparse(const char *input_path, int map_type, const char *map_name, bool extract_stream) {
-    std::string &&result = std::move(_parse(DefaultAnalyzer(input_path), map_type, NULL, map_name, 300, 150));
-    return result.c_str();
-}
+    else
+    {
+        return _parse(DefaultAnalyzer(s.input_path), s);
+    }
 }

--- a/src/README.md
+++ b/src/README.md
@@ -8,10 +8,9 @@ It is firstly developed at 2020 to support running of aocrec.com as a
 replacement of a prior php parser( which was a modified version of recanalyst).
 
 ## Basic usage
-MgxParser exports two forms of `parse()` function:
+MgxParser `parse(Settings)` function:
 One takes a record file path as input and returns a JSON string contains
 important information about this record.  
-The other accepts a byte(uint8_t) array and parses the data.
 
 If input is a zip archive, MgxParser will try to Extract2Files first file in the
 archive and parse it as a record. This function is intended to tackle compressed
@@ -21,15 +20,31 @@ No error was expected even if something unexpected happend in parsing process.
 Users should check parsing result by the value of key `status` and `message` in
 JSON response.
 
-Mini maps can be generated two forms, too.   
-With `-m`, a typical map was generated, and   
-with `-M`, a prettier HD map was generated.
+**Read `src/include/MgxParse.h` for more details.**
 
-With `-e` to extract header and body data to .dat files for development usage.
+A demo of MgxParser will be compiled using demo.cc. It can be used to parse a
+record file and print the result to stdout.
+```sh
+mgxparser --help
+```
+Output:
+```sh
+Usage: ./mgxparser [options] [file]
+Options:
+  -m    Generate a normal map
+  -M    Generate a HD map
+  -u    Extract the original file in .zip archive
+  -j    Indentation of the json string. i.e. -j2
+  --help Display this help message
+Example: ./mgxparser -m -j2 demo.mgx
+```
+
+For node addon usage, see `src/node/README.md`,    
+See **Compile node addon with cmake-js** for details.
 
 ## Performance
-I did't do elegent profiling for it, simply measured its performance by `\time -v
-MgxParser recordfile.mgx`
+I did't do elegent profiling for it, simply measured its performance    
+by `\time -v MgxParser recordfile.mgx`   
 
 Pure json output without map generation is very fast. Normally cost
 <50ms and <10m peak memory( in my synology DS1621+ NAS docker container).
@@ -88,6 +103,10 @@ can be installed by:
 ```sh
 sudo snap install cmake --classic
 ```
+or
+```sh
+sudo apt-get install cmake
+```
 
 A C++17 compiler is also needed. `G++-9`, `Clang++-10` or newer compilers are
 recommended. Other compilers may work, but I never tested, too.
@@ -101,18 +120,22 @@ cmake . -DCMAKE_CXX_COMPILER=/usr/bin/clang++-10 -DCMAKE_BUILD_TYPE=Release --fr
 make
 ```
 
-## Compile with cmake-js
-- Use `add_subdirectories()` funtion of CMake to integrate MgxParser into a
-Node.js addon. 
-- `set(NODE_ADDON 1)` in root `CMakeLists.txt`, MgxParser should adjust the proper
-  CMake settings automatically.
-- Put `$<TARGET_OBJECTS:MgxParser>` as an `<item>` of `add_library()` directive
-  of root `CMakeLists.txt`.
-- Include `src/include/MgxParse.h`.
-
-Then `MgxParser::parse()` should be available.
+## Compile node addon with cmake-js
+To compile it to a node addon, `cmake-js` and `node-addon-api` is required.   
+Use `npm` to install `cmake-js` and `node-addon-api`:
+```sh
+npm install
+```
+Then, compile it with `cmake-js`:
+```sh
+npx cmake-js compile -p 6 # or other threads settings
+```
+The compiled node addon will be in `build/Release` directory.   
+A demo of node addon is in `test/node_addon_test.js` directory.
 
 ## Version log
+- **0.4.2**: Reorganized source code. Refactored `parse()` function. Add node addon support.   
+- **0.4.1**: A version used on aocrec.com before Feb. 2024.
 - **0.4.0**: Prepare to go online. Add english language pack. Fixed more bugs.
 - **0.3.x**: Bug fix and some changes to meet requirements of mgxhub.
 - **0.2.0**: Reoragnized source files, tested with 130000+ records in

--- a/src/analyzers/default/addon_drawmap.cc
+++ b/src/analyzers/default/addon_drawmap.cc
@@ -2,7 +2,7 @@
  * \file       addon_generatemap.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/addon_extract2files.cc
+++ b/src/analyzers/default/addon_extract2files.cc
@@ -2,7 +2,7 @@
  * \file       addon_streamtofile.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/addon_filemd5.cc
+++ b/src/analyzers/default/addon_filemd5.cc
@@ -2,7 +2,7 @@
  * \file       addon_filemd5.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/30
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <string>

--- a/src/analyzers/default/addon_guesswinner.cpp
+++ b/src/analyzers/default/addon_guesswinner.cpp
@@ -2,7 +2,7 @@
  * \file       addon_guesswinner.cpp
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <vector>

--- a/src/analyzers/default/addon_guid.cc
+++ b/src/analyzers/default/addon_guid.cc
@@ -2,7 +2,7 @@
  * \file       addon_guid.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/analyzer.cc
+++ b/src/analyzers/default/analyzer.cc
@@ -2,7 +2,7 @@
  * \file       analyzer.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <sstream>

--- a/src/analyzers/default/analyzer.h
+++ b/src/analyzers/default/analyzer.h
@@ -2,7 +2,7 @@
  * \file       analyzer.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_DEFAULTANALYZER_H_
@@ -148,9 +148,11 @@ public:
 
     /**
      * Serialize record information into a json string
+     * @param indent Indentation of output JSON string. Default is -1.
+     * 
      * @return C++ string. Need to be parsed.
      */
-    std::string JsonOutput();
+    std::string JsonOutput(int indent = -1);
 
     /**
      * Append a message to output result.

--- a/src/analyzers/default/body_processors/action_handlers.cc
+++ b/src/analyzers/default/body_processors/action_handlers.cc
@@ -2,7 +2,7 @@
  * \file       action_handlers.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <cstdint>

--- a/src/analyzers/default/body_processors/operation_handlers.cc
+++ b/src/analyzers/default/body_processors/operation_handlers.cc
@@ -2,7 +2,7 @@
  * \file       operation_handlers.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <string>

--- a/src/analyzers/default/mainproc_bodycommands.cpp
+++ b/src/analyzers/default/mainproc_bodycommands.cpp
@@ -2,7 +2,7 @@
  * \file       mainproc_bodycommands.cpp
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/mainproc_extractstreams.cc
+++ b/src/analyzers/default/mainproc_extractstreams.cc
@@ -2,7 +2,7 @@
  * \file       mainproc_extractstreams.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <array>
@@ -135,7 +135,7 @@ bool DefaultAnalyzer::ExtractStreams() {
     // Unzip the record if requested
     // 这儿要注意的问题是不能放在上面解压的代码那里，因为刚解压完并不知道压缩包里这个文件是不是有效录像，所以那时候解压出来没意义
     if (is_zip) {
-        if (unzip_buffer_) {
+        if (unzip_ == "buffer" && unzip_size_ptr_) {
             // remember to free memory if using this!!!
             *unzip_buffer_ = (char *)malloc(*unzip_size_ptr_ = input_size_);
             memcpy(*unzip_buffer_, input_stream_.data(), input_size_);

--- a/src/analyzers/default/mainproc_jsondump.cc
+++ b/src/analyzers/default/mainproc_jsondump.cc
@@ -2,7 +2,7 @@
  * \file       mainproc_jsondump.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"
@@ -43,7 +43,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM
      { UNDEFINED, "UNDEFINED" }
  });
 
-std::string DefaultAnalyzer::JsonOutput() {
+std::string DefaultAnalyzer::JsonOutput(int indent) {
     json j;
 
     // Report
@@ -196,5 +196,5 @@ std::string DefaultAnalyzer::JsonOutput() {
         j["players"].emplace_back(std::move(pj));
     }
 
-    return j.dump(-1, ' ', false, json::error_handler_t::ignore);
+    return j.dump(indent, ' ', false, json::error_handler_t::ignore);
 }

--- a/src/analyzers/default/mainproc_loadfile.cc
+++ b/src/analyzers/default/mainproc_loadfile.cc
@@ -2,7 +2,7 @@
  * \file       mainproc_loadfile.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/status.h
+++ b/src/analyzers/default/status.h
@@ -2,7 +2,7 @@
  * \file       status.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <string>

--- a/src/analyzers/default/subproc_ai.cc
+++ b/src/analyzers/default/subproc_ai.cc
@@ -2,7 +2,7 @@
  * \file       subproc_ai.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <algorithm>

--- a/src/analyzers/default/subproc_deheader.cc
+++ b/src/analyzers/default/subproc_deheader.cc
@@ -2,7 +2,7 @@
  * \file       subproc_deheader.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_detectencoding.cc
+++ b/src/analyzers/default/subproc_detectencoding.cc
@@ -2,7 +2,7 @@
  * \file       subproc_detectencoding.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_detectversion.cc
+++ b/src/analyzers/default/subproc_detectversion.cc
@@ -2,7 +2,7 @@
  * \file       subproc_detectversion.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_finddisabledtechs.cc
+++ b/src/analyzers/default/subproc_finddisabledtechs.cc
@@ -2,7 +2,7 @@
  * \file       subproc_finddisabledtechs.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_findgamesettings.cc
+++ b/src/analyzers/default/subproc_findgamesettings.cc
@@ -2,7 +2,7 @@
  * \file       subproc_findgamesettings.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
  
 #include <array>

--- a/src/analyzers/default/subproc_findinitialpos.cc
+++ b/src/analyzers/default/subproc_findinitialpos.cc
@@ -2,7 +2,7 @@
  * \file       subproc_findinitialpos.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_findtrigger.cc
+++ b/src/analyzers/default/subproc_findtrigger.cc
@@ -2,7 +2,7 @@
  * \file       subproc_findtrigger.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <array>

--- a/src/analyzers/default/subproc_gamesettings.cc
+++ b/src/analyzers/default/subproc_gamesettings.cc
@@ -2,7 +2,7 @@
  * \file       subproc_gamesettings.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_hdheader.cc
+++ b/src/analyzers/default/subproc_hdheader.cc
@@ -2,7 +2,7 @@
  * \file       subproc_hdheader.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_intialdata.cc
+++ b/src/analyzers/default/subproc_intialdata.cc
@@ -2,7 +2,7 @@
  * \file       subproc_intialdata.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include <map>

--- a/src/analyzers/default/subproc_lobby.cc
+++ b/src/analyzers/default/subproc_lobby.cc
@@ -2,7 +2,7 @@
  * \file       subproc_lobby.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_map.cc
+++ b/src/analyzers/default/subproc_map.cc
@@ -2,7 +2,7 @@
  * \file       subproc_map.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_messages.cc
+++ b/src/analyzers/default/subproc_messages.cc
@@ -2,7 +2,7 @@
  * \file       subproc_messages.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_replay.cc
+++ b/src/analyzers/default/subproc_replay.cc
@@ -2,7 +2,7 @@
  * \file       subproc_replay.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_scenario.cc
+++ b/src/analyzers/default/subproc_scenario.cc
@@ -2,7 +2,7 @@
  * \file       subproc_scenario.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_skiptriggers.cc
+++ b/src/analyzers/default/subproc_skiptriggers.cc
@@ -2,7 +2,7 @@
  * \file       subproc_skiptriggers.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/analyzers/default/subproc_victory.cc
+++ b/src/analyzers/default/subproc_victory.cc
@@ -2,7 +2,7 @@
  * \file       subproc_victory.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "analyzer.h"

--- a/src/auxiliary.h
+++ b/src/auxiliary.h
@@ -2,7 +2,7 @@
  * \file       auxiliary.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_AUXILIARY_H_

--- a/src/datamodels/chat.h
+++ b/src/datamodels/chat.h
@@ -2,7 +2,7 @@
  * \file       chat.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_DATAMODEL_CHAT_H_

--- a/src/datamodels/player.h
+++ b/src/datamodels/player.h
@@ -2,7 +2,7 @@
  * \file       player.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_DATAMODEL_PLAYER_H_

--- a/src/datamodels/record.h
+++ b/src/datamodels/record.h
@@ -2,7 +2,7 @@
  * \file       record.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_DATAMODEL_RECORD_H_

--- a/src/include/MgxParser.h
+++ b/src/include/MgxParser.h
@@ -2,78 +2,80 @@
  * \file       MgxParser.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/7
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_H_
 #define MGXPARSER_H_
 
-#define NO_MAP 0
-#define NORMAL_MAP 1
-#define HD_MAP 2
-#define MAP_NAME "minimap.png"
-
 #include <string>
 #include <cstdio>
 
-namespace MgxParser {
-/**
- * Settings for parser
- * @param input_stream   Pointer to input stream
- * @param input_path     Path to input file
- * @param input_size     In bytes
- * @param map_type       NO_MAP(Default), NORMAL_MAP, HD_MAP
- * @param map_width      Map width
- * @param map_height     Map heigth
- * @param map_name       Name of generated map file
- * @param map_dest       A C-style FILE handler to store map
- * @param extract_stream Extract header&body streams to files. Default filenames: header.dat, body.dat
- * @param header_path
- * @param body_path
- * @param full_parse
- * @param md5
- * @param extract_stream
- * @param unzip
- * @param unzip_buffer
- */
-struct Settings {
-    const uint8_t *input_stream = nullptr;
-    std::string input_path;
-    size_t input_size = 0;
-    int map_type = NO_MAP;
-    int map_width = 300;
-    int map_height = 150;
-    std::string map_name;
-    FILE *map_dest = NULL;
-    bool extract_stream = false;
-    std::string header_path;
-    std::string body_path;
-    bool full_parse = true;
-    bool md5 = true;
-    std::string unzip;
-    char **unzip_buffer = nullptr;
-    std::size_t *unzip_size_ptr = nullptr;
-};
+namespace MgxParser
+{
+    /**
+     * Map type
+     * NO_MAP: Don't generate map
+     * NORMAL_MAP: Generate a normal map
+     * HD_MAP: Generate a high definition map based on the normal map
+     */
+    enum MapType
+    {
+        NO_MAP = 0,
+        NORMAL_MAP,
+        HD_MAP
+    };
 
-/**
- * Parse a data stream or a record file. Also accept a .zip archive containing a valid record as its first file.
- * @return               A json string contains parsed results.
- */
-std::string parse(Settings &settings);
+    /**
+     * Settings for parser
+     * The parsing result is determined by the settings.
+     * 
+     * @param input_stream   Pointer to input stream. If not nullptr, the parser will use the stream instead of the file.
+     * @param input_path     Path to input file. If input_stream is not NULL, this field will be ignored.
+     * @param input_size     In bytes.
+     * @param map_type       NO_MAP(Default), NORMAL_MAP, HD_MAP.
+     * @param map_width      Map width. Default is 300.
+     * @param map_height     Map heigth. Default is 150.
+     * @param map_path       Path of generated map file.
+     * @param map_dest       A C-style FILE handler to store map. If not NULL, the map will be written to the file.
+     * @param header_path    If a path is provided, the header part of the record file will be extracted to the file. i.e. "header.dat".
+     * @param body_path      If a path is provided, the body part of the record file will be extracted to the file. i.e. "body.dat".
+     * @param full_parse     Parse the record file. Set to false if you only want to generate a map or extract raw data for record analyzing.
+     * @param calc_md5       Calculate md5 of actuall record file(or data stream). It is useful when handling .zip archive, md5 of the real record file is different from the .zip file.
+     * @param unzip          Extract record file from a .zip archive. If not empty, it should be a path to a .zip archive. Use "original" to retain the orignal filename in .zip archive. Use "buffer" to extract the record file to a buffer.
+     * @param unzip_buffer   If you want to extract the record file to a buffer, provide a pointer to a buffer pointer. After parsing, the buffer will be allocated and the pointer will be assigned to it.
+     * @param unzip_size_ptr Used to store the allocated buffer size. After parsing, the size of the buffer will be assigned to it. Required if unzip is "buffer".
+     * @param json_indent    Indentation of the json string. -1 for no indentation.
+     */
+    struct Settings
+    {
+        const uint8_t *input_stream = nullptr;
+        std::string input_path;
+        size_t input_size = 0;
+        MapType map_type = NO_MAP;
+        unsigned map_width = 300;
+        unsigned map_height = 150;
+        std::string map_path;
+        FILE *map_dest = NULL;
+        std::string header_path;
+        std::string body_path;
+        bool full_parse = true;
+        bool calc_md5 = true;
+        std::string unzip;
+        char **unzip_buffer = nullptr;
+        std::size_t *unzip_size_ptr = nullptr;
+        int json_indent = -1;
+    };
 
-/**
- * To be used in building a python extension, not tested.
- * @param input_path     Path to input file. A C-style string.
- * @param map_type       NO_MAP(Default), NORMAL_MAP, HD_MAP
- * @param map_name       Name of generated map file
- * @param extract_stream Extract header&body streams to files. Default filenames: header.dat, body.dat
- * @return               A json string(C-style string) contains parsed results.
- */
-extern "C" const char *pyparse(
-    const char *input_path,
-    int map_type = NO_MAP,
-    const char *map_name = MAP_NAME,
-    bool extract_stream = false);
-}  // namespace MgxParser
+    /**
+     * Parse a data stream or a record file. Also accept a .zip archive containing a valid record as its first file.
+     * Behavior of the parser is controlled by the settings, read the definition of Settings above for more details. 
+     * 
+     * @param s            Input settings
+     * @return             A json string contains parsing results.
+     */
+    std::string parse(Settings &s);
 
-#endif  // MGXPARSER_H_
+} // namespace MgxParser
+
+#endif // MGXPARSER_H_

--- a/src/lang/zh.h
+++ b/src/lang/zh.h
@@ -2,7 +2,7 @@
  * \file       zh.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_ZN_LANG_H_

--- a/src/tools/bytestohex.cc
+++ b/src/tools/bytestohex.cc
@@ -2,7 +2,7 @@
  * \file       bytestohex.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "bytestohex.h"

--- a/src/tools/bytestohex.h
+++ b/src/tools/bytestohex.h
@@ -2,7 +2,7 @@
  * \file       bytestohex.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
  
 #ifndef MGXPARSER_BYTESTOHEX_H_

--- a/src/tools/cursor.cc
+++ b/src/tools/cursor.cc
@@ -2,7 +2,7 @@
  * \file       cursor.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "cursor.h"

--- a/src/tools/cursor.h
+++ b/src/tools/cursor.h
@@ -2,7 +2,7 @@
  * \file       cursor.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_CURSOR_H_

--- a/src/tools/logger.h
+++ b/src/tools/logger.h
@@ -2,7 +2,7 @@
  * \file       logger.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_LOGGER_H_

--- a/src/tools/map/map_colors.h
+++ b/src/tools/map/map_colors.h
@@ -2,7 +2,7 @@
  * \file       map_colors.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_MAP_COLORS_H_

--- a/src/tools/map/map_parser.h
+++ b/src/tools/map/map_parser.h
@@ -2,7 +2,7 @@
  * \file       map_parser.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_MAP_PARSER_H_

--- a/src/tools/map/map_tiles.h
+++ b/src/tools/map/map_tiles.h
@@ -2,7 +2,7 @@
  * \file       map_tiles.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_MAP_TILES_H_

--- a/src/tools/searcher.h
+++ b/src/tools/searcher.h
@@ -2,7 +2,7 @@
  * \file       searcher.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_SEARCHER_H_

--- a/src/tools/zipdecompress.cc
+++ b/src/tools/zipdecompress.cc
@@ -2,7 +2,7 @@
  * \file       zipdecompress.cc
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #include "zipdecompress.h"

--- a/src/tools/zipdecompress.h
+++ b/src/tools/zipdecompress.h
@@ -2,7 +2,7 @@
  * \file       zipdecompress.h
  * \author     PATRICK LI (admin@aocrec.com)
  * \date       2022/11/8
- * \copyright  Copyright (c) 2020-2022
+ * \copyright  Copyright (c) 2020-2024
  ***************************************************************/
 
 #ifndef MGXPARSER_ZIPTOOL_H_

--- a/test/node_addon_test.js
+++ b/test/node_addon_test.js
@@ -1,0 +1,27 @@
+'use strict';
+const path = require('path');
+
+// 检查是否提供了命令行参数
+if (process.argv.length < 3) {
+  console.error('请提供.node文件的路径');
+  process.exit(1);
+}
+
+// 加载C++扩展
+const addonPath = path.resolve(process.argv[2]);
+const addon = require(addonPath);
+
+// 使用C++扩展
+const addonDir = path.dirname(addonPath);
+const imagePath = path.join(addonDir, 'testmap.png');
+
+const parsed = addon.parse({
+  input: path.resolve('test/test_records/AOC10_4v4_3_192a8268.zip'),
+  map: 'hd', // lowercase, or 'normal'
+  mapWidth: 600,
+  mapHeight: 300,
+  mapName: imagePath,
+  jsonIndent: 2
+});
+
+console.log(parsed.result);

--- a/test/test.cc
+++ b/test/test.cc
@@ -42,17 +42,17 @@ bool isPng(string f)
 class ParserTest : public testing::Test
 {
 protected:
-    void load(json &j, string f, int mapType = NO_MAP, string mapName = "testmap.png")
+    void load(json &j, string f, MgxParser::MapType mapType = MgxParser::NO_MAP, string mapName = "testmap.png")
     {
         auto path = genPath(f);
-        MgxParser::Settings _ = {.input_path = path, .map_type = mapType, .map_name = mapName};
+        MgxParser::Settings _ = {.input_path = path, .map_type = mapType, .map_path = mapName};
         string rawret = MgxParser::parse(_);
         j = json::parse(rawret);
     }
 
-    void loadBytes(json &j, const uint8_t *b, uint32_t size, int mapType = NO_MAP, string mapName = "testmap.png")
+    void loadBytes(json &j, const uint8_t *b, uint32_t size, MgxParser::MapType mapType = MgxParser::NO_MAP, string mapName = "testmap.png")
     {
-        MgxParser::Settings _ = {.input_stream = b, .input_size = size, .map_type = mapType, .map_name = mapName};
+        MgxParser::Settings _ = {.input_stream = b, .input_size = size, .map_type = mapType, .map_path = mapName};
         string rawret = MgxParser::parse(_);
         j = json::parse(rawret);
     }
@@ -74,7 +74,7 @@ TEST_F(ParserTest, AOC10ZipwithMap)
     EXPECT_EQ(recA["message"], "");
 
     string mapName = "testmap.png";
-    load(recB, "AOC10_4v4_3_192a8268.zip", HD_MAP, mapName);
+    load(recB, "AOC10_4v4_3_192a8268.zip", MgxParser::HD_MAP, mapName);
     // A map file is successfully generated,
     EXPECT_TRUE(filesystem::exists(filesystem::path(mapName)));
     // and is a valid png file.
@@ -101,7 +101,7 @@ TEST_F(ParserTest, AOC10CZip)
 TEST_F(ParserTest, AOKwithMap)
 {
     string mapName = "中文名地图.png";
-    load(recA, "AOK_1v1_2_64b2d6dd.zip", NORMAL_MAP, mapName);
+    load(recA, "AOK_1v1_2_64b2d6dd.zip", MgxParser::NORMAL_MAP, mapName);
     EXPECT_EQ(recA["version"]["code"], "AOK");
     EXPECT_EQ(recA["message"], "");
     EXPECT_EQ(recA["duration"], 2364525);


### PR DESCRIPTION
- Integrated node addon code. Now can compile node addon in one project.
- Add a test script for node addon in `test/`
- Cleaned CMakeList.txt, removed workaround codes for windows and macOS
- Updated code of demo executable
- Refactored interface of MgxParser.h